### PR TITLE
Associating frames to slices

### DIFF
--- a/aseprite.go
+++ b/aseprite.go
@@ -59,6 +59,9 @@ type Frame struct {
 
 // Slice represents a single slice.
 type Slice struct {
+	// Name is the name of the slice. Can be duplicate.
+	Name string
+
 	// Bounds is the bounds of the image in the texture atlas.
 	Bounds image.Rectangle
 
@@ -68,14 +71,28 @@ type Slice struct {
 	// Pivot is the pivot point relative to Bounds.
 	Pivot image.Point
 
-	// Name is the name of the slice. Can be duplicate.
-	Name string
+	// // Keys is the slice keys. Each slice has its own keyframes
+	Keys []SliceKeyFrame
 
 	// Data is optional user data.
 	Data []byte
 
 	// Color is the slice color.
 	Color color.Color
+}
+
+type SliceKeyFrame struct {
+	// FrameIndex is the index of the frame associated to this key frame
+	FrameIndex int
+
+	// Bounds is the bounds of the image in the texture atlas.
+	Bounds image.Rectangle
+
+	// Center is the 9-slices center relative to Bounds.
+	Center image.Rectangle
+
+	// Pivot is the pivot point relative to Bounds.
+	Pivot image.Point
 }
 
 // Aseprite holds the results of a parsed Aseprite image file.

--- a/parse.go
+++ b/parse.go
@@ -204,12 +204,16 @@ func (f *file) buildTags() []Tag {
 }
 
 func parseSlice(s *Slice, flags uint32, raw []byte) []byte {
-	// framenum := binary.LittleEndian.Uint32(raw)
+	var key SliceKeyFrame
+
+	key.FrameIndex = int(binary.LittleEndian.Uint32(raw))
 	x := int32(binary.LittleEndian.Uint32(raw[4:]))
 	y := int32(binary.LittleEndian.Uint32(raw[8:]))
 	w := binary.LittleEndian.Uint32(raw[12:])
 	h := binary.LittleEndian.Uint32(raw[16:])
 	raw = raw[20:]
+
+	key.Bounds = image.Rect(int(x), int(y), int(x)+int(w), int(y)+int(h))
 
 	var cx, cy int32
 	var cw, ch uint32
@@ -220,6 +224,8 @@ func parseSlice(s *Slice, flags uint32, raw []byte) []byte {
 		cw = binary.LittleEndian.Uint32(raw[8:])
 		ch = binary.LittleEndian.Uint32(raw[12:])
 		raw = raw[16:]
+
+		key.Center = image.Rect(int(cx), int(cy), int(cx)+int(cw), int(cy)+int(ch))
 	}
 
 	var px, py int32
@@ -228,11 +234,10 @@ func parseSlice(s *Slice, flags uint32, raw []byte) []byte {
 		px = int32(binary.LittleEndian.Uint32(raw))
 		py = int32(binary.LittleEndian.Uint32(raw[4:]))
 		raw = raw[8:]
+		key.Pivot = image.Pt(int(px), int(py))
 	}
 
-	s.Bounds = image.Rect(int(x), int(y), int(x)+int(w), int(y)+int(h))
-	s.Center = image.Rect(int(cx), int(cy), int(cx)+int(cw), int(cy)+int(ch))
-	s.Pivot = image.Pt(int(px), int(py))
+	s.Keys = append(s.Keys, key)
 
 	return raw
 }
@@ -243,18 +248,21 @@ func (f *file) buildSlices() (slices []Slice) {
 		if chunk.typ == 0x2022 {
 			ofs := len(slices)
 			raw := chunk.raw
-			nslices := int(binary.LittleEndian.Uint32(raw))
+
+			nKeysForSlice := int(binary.LittleEndian.Uint32(raw))
 			flags := binary.LittleEndian.Uint32(raw[4:])
 			name := parseString(raw[12:])
 
-			// parse each slice
 			raw = raw[14+len(name):]
-			for i := 0; len(raw) > 0 && i < nslices; i++ {
-				var s Slice
-				s.Name = name
+
+			var s Slice
+			s.Name = name
+
+			// parse each slice
+			for i := 0; len(raw) > 0 && i < nKeysForSlice; i++ {
 				raw = parseSlice(&s, flags, raw)
-				slices = append(slices, s)
 			}
+			slices = append(slices, s)
 
 			// check for user data chunk
 			if i < len(chunks)-1 {


### PR DESCRIPTION
I have a need to use slices as hitboxes in my game and noticed that the slices weren't associated to a frame, so I am adding the ability to associate slices to frames. 

This was very useful to me. Feel free to request any changes. My code is not great, I don't understand the aseprite data model fully, and this was AI assisted. 

I really appreciate your library and wanted to contribute back if I could. If this isn't wanted as part of your library feel free to decline the contribution. 

I have not fully tested this code but from my preliminary tests it appears to be working well