### PR TITLE
Slice frames feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/aseprite.go
+++ b/aseprite.go
@@ -57,9 +57,25 @@ type Frame struct {
 	Data [][]byte
 }
 
-// Slice represents a single slice.
+// Slice represents Aseprite's slice.
 type Slice struct {
-	// Bounds is the bounds of the image in the texture atlas.
+	// Name is the name of the slice. Can be duplicate.
+	Name string
+
+	// Color is the slice color.
+	Color color.Color
+
+	// UserData is optional user data.
+	UserData []byte
+
+	// Frames contains the slice geometry for each animation frame.
+	// Index corresponds to frame number; expanded from sparse keyframes.
+	Frames []SliceFrame
+}
+
+type SliceFrame struct {
+
+	// Bounds is the bounds of the slice.
 	Bounds image.Rectangle
 
 	// Center is the 9-slices center relative to Bounds.
@@ -67,15 +83,6 @@ type Slice struct {
 
 	// Pivot is the pivot point relative to Bounds.
 	Pivot image.Point
-
-	// Name is the name of the slice. Can be duplicate.
-	Name string
-
-	// Data is optional user data.
-	Data []byte
-
-	// Color is the slice color.
-	Color color.Color
 }
 
 // Aseprite holds the results of a parsed Aseprite image file.


### PR DESCRIPTION
The slice struct has been adapted to Aseprite behavior. All keys are expanded and filled. It is guaranteed that each frame has a slice.

test file 
[slicekeys.zip](https://github.com/user-attachments/files/24691555/slicekeys.zip)


```Go
package main

import (
	"image"
	"os"

	"github.com/anthonynsimon/bild/imgio"
	"github.com/askeladdk/aseprite"
	"github.com/davecgh/go-spew/spew"
)

func main() {

	ase := newAseFromFile("slices.ase")

	spew.Dump(ase.Slices[0])

	// 	(aseprite.Slice) {
	//  Name: (string) (len=7) "Slice 1",
	//  Color: (color.NRGBA) {
	//   R: (uint8) 0,
	//   G: (uint8) 0,
	//   B: (uint8) 255,
	//   A: (uint8) 255
	//  },
	//  UserData: ([]uint8) {
	//  },
	//  Frames: ([]aseprite.SliceFrame) (len=3 cap=4) {
	//   (aseprite.SliceFrame) {
	//    Bounds: (image.Rectangle) (17,8)-(49,35),
	//    Center: (image.Rectangle) (0,0)-(0,0),
	//    Pivot: (image.Point) (0,0)
	//   },
	//   (aseprite.SliceFrame) {
	//    Bounds: (image.Rectangle) (0,0)-(50,20),
	//    Center: (image.Rectangle) (0,0)-(0,0),
	//    Pivot: (image.Point) (0,0)
	//   },
	//   (aseprite.SliceFrame) {
	//    Bounds: (image.Rectangle) (18,5)-(38,56),
	//    Center: (image.Rectangle) (0,0)-(0,0),
	//    Pivot: (image.Point) (0,0)
	//   }
	//  }
	// }

	sliceImg1 := SliceImage(1, ase.Slices[0], ase)
	sliceImg2 := SliceImage(2, ase.Slices[0], ase)
	imgio.Save("slice_img1.png", sliceImg1, imgio.PNGEncoder())
	imgio.Save("slice_img2.png", sliceImg2, imgio.PNGEncoder())

}

func SliceImage(frameIndex int, s aseprite.Slice, a *aseprite.Aseprite) image.Image {
	sliceImg := a.Image.(subImager).SubImage(a.Frames[frameIndex].Bounds).(*image.RGBA)
	sliceRect := s.Frames[frameIndex].Bounds.Add(a.Frames[frameIndex].Bounds.Min)
	return sliceImg.SubImage(sliceRect)
}

type subImager interface {
	SubImage(image.Rectangle) image.Image
}

func newAseFromFile(path string) (ase *aseprite.Aseprite) {
	f, err := os.Open(path)
	if err != nil {
		panic(err)
	}
	defer f.Close()
	ase, err = aseprite.Read(f)
	if err != nil {
		panic(err)
	}
	return
}

```